### PR TITLE
gluon-config-mode-site-select: Update to gluon v2017.1 and newer

### DIFF
--- a/gluon-config-mode-site-select/Makefile
+++ b/gluon-config-mode-site-select/Makefile
@@ -8,14 +8,16 @@ PKG_BUILD_DEPENDS := lua-cjson/host
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 
-include $(INCLUDE_DIR)/package.mk
+include $(TOPDIR)/../package/gluon.mk
 
+GLUON_SITEDIR = '$(call qstrip,$(CONFIG_GLUON_SITEDIR))'
 PKG_CONFIG_DEPENDS += $(GLUON_I18N_CONFIG)
 
 define Package/gluon-config-mode-site-select
   SECTION:=gluon
   CATEGORY:=Gluon
   TITLE:=UI for changing the node-config
+  DEPENDS:=+gluon-core
 endef
 
 define Build/Prepare


### PR DESCRIPTION
 * Missing GLUON_SITEDIR produces build error in site-ffm
 * Missing GLUON_I18N_CONFIG (defined in gluon.mk) breaks i18n (#2)
 * see [gluon v2017.1 release notes](https://gluon.readthedocs.io/en/v2017.1.x/releases/v2017.1.html#internals) for further details

This fixes the following build error with site-ffm:
````
$ lua -e 'print(require("cjson").encode(assert(loadfile("site_config.lua")("/extra/ffmuc.conf"))))' > …/ffmuc.json
lua: site_config.lua:9: site_config.lua:5: attempt to index a nil value
stack traceback:
	[C]: ?
	[C]: in function 'load'
	site_config.lua:9: in main chunk
	(command line):1: in main chunk
	[C]: ?
stack traceback:
	[C]: in function 'assert'
	site_config.lua:9: in main chunk
	(command line):1: in main chunk
	[C]: ?

````