### PR TITLE
fix domain_migration for gluon v2018.2

### DIFF
--- a/gluon-domain-migration-ffmuc/files/lib/gluon/upgrade/002-domain-migration
+++ b/gluon-domain-migration-ffmuc/files/lib/gluon/upgrade/002-domain-migration
@@ -1,6 +1,7 @@
 #!/usr/bin/lua
 
-local fs = require 'nixio.fs'
+local sys_stat = require 'posix.sys.stat'
+local pio = require 'posix.stdio'
 local uci = require("simple-uci").cursor()
 
 local file = '/etc/config/currentsite'
@@ -11,10 +12,10 @@ end
 if uci:get('gluon', 'system') then
 	uci:delete('gluon', 'system')
 end
-if fs.stat(file) then
+if sys_stat.stat(file) then
 	local domain = uci:get('currentsite', 'current', 'name')
 	uci:set('gluon', 'core', 'domain', domain)
-	fs.remove(file)
+	os.remove(file)
 end
 
 uci:save('gluon')
@@ -36,8 +37,8 @@ end
 fout:close()
 
 if exist then
-	fs.remove(sysfile)
-	fs.move(tmpsysfile, sysfile)
+	os.remove(sysfile)
+	pio.rename(tmpsysfile, sysfile)
 else
-	fs.remove(tmpsysfile)
+	os.remove(tmpsysfile)
 end


### PR DESCRIPTION
remove usage of nixio and use luaposix instead