### PR TITLE
add ffho-ap-timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ State of the different packages:
   - Package to obtain surrounding wifis to obtionally request the location from a locator service
   - used by ffmuc-geolocator
 
+- ffho-ap-timer
+  - Upstream: https://github.com/FreifunkHochstift/ffho-packages/tree/a2521ef/ffho-ap-timer
+  - Timer for the client wifi with three modes (daily, weekly, monthly)
+
+- ffho-web-ap-timer
+  - Upstream: https://github.com/FreifunkHochstift/ffho-packages/tree/a2521ef/ffho-web-ap-timer
+  - Config mode implementation for ffho-ap-timer
+
 - ffmuc-domain-director
   - Based on https://github.com/freifunk-darmstadt/ffda-packages/tree/57622c7/ffda-domain-director
   - Makes the node ask a director for zone configuration

--- a/ffho-ap-timer/Makefile
+++ b/ffho-ap-timer/Makefile
@@ -1,0 +1,22 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ffho-ap-timer
+PKG_VERSION:=1
+
+PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
+
+include $(TOPDIR)/../package/gluon.mk
+
+define Package/ffho-ap-timer
+  SECTION:=ffho
+  CATEGORY:=FFHO
+  TITLE:=Timer for the client wifi
+  DEPENDS:=+gluon-core
+  MAINTAINER:=Freifunk Hochstift <kontakt@hochstift.freifunk.net>
+endef
+
+define Package/ffho-ap-timer/description
+	Timer for the client wifi
+endef
+
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))

--- a/ffho-ap-timer/ReadMe.md
+++ b/ffho-ap-timer/ReadMe.md
@@ -1,0 +1,33 @@
+ffho-ap-timer
+=============
+
+Timer for the client wifi with three modes (daily, weekly, monthly)
+
+/etc/config/ap-timer
+-------------------
+
+**ap-timer.settings.enabled:**
+- `0` disables the ap-timer (default)
+- `1` enables the ap-timer
+
+**ap-timer.settings.type:**
+- `day`, $day = all
+- `week`, $day = [Mon|Tue|Wed|Thu|Fri|Sat|Sun]
+- `month`, $day = [01-31]
+
+**ap-timer.$day.on:**
+- List of time to enable wireless
+
+**ap-timer.$day.off:**
+- List of time to disable wireless
+
+### example
+```
+config ap-timer 'settings'
+	option enabled '1'
+	option type 'week'
+
+config week 'Sun'
+	list on '06:00'
+	list off '23:00'
+```

--- a/ffho-ap-timer/files/etc/config/ap-timer
+++ b/ffho-ap-timer/files/etc/config/ap-timer
@@ -1,0 +1,7 @@
+#config ap-timer 'settings'
+#	option enabled '1'
+#	option type 'day'
+#
+#config day 'all'
+#	list on '06:00'
+#	list off '23:00'

--- a/ffho-ap-timer/files/lib/gluon/upgrade/900-remove-aptimer-config
+++ b/ffho-ap-timer/files/lib/gluon/upgrade/900-remove-aptimer-config
@@ -1,0 +1,2 @@
+#!/bin/sh
+rm -f /etc/config/aptimer

--- a/ffho-ap-timer/files/usr/lib/micron.d/ap-timer
+++ b/ffho-ap-timer/files/usr/lib/micron.d/ap-timer
@@ -1,0 +1,1 @@
+* * * * * /usr/sbin/ap-timer

--- a/ffho-ap-timer/luasrc/usr/sbin/ap-timer
+++ b/ffho-ap-timer/luasrc/usr/sbin/ap-timer
@@ -1,0 +1,58 @@
+#!/usr/bin/lua
+local timestamp = os.time()
+local uci = require('simple-uci').cursor()
+
+local function compare(list, value)
+  if not list then
+    return nil
+  end
+
+  for _, v in ipairs(list) do
+    if v == value then
+      return true
+    end
+  end
+
+  return false
+end
+
+local function getDay()
+  local type = uci:get('ap-timer', 'settings', 'type')
+  if type == 'day' then return 'all'
+  elseif type == 'week' then return os.date('%a', timestamp)
+  elseif type == 'month' then return os.date('%d', timestamp)
+  else return nil
+  end
+end
+
+local function apSet(enable)
+  local execWifi = false
+  local radios = {'client_radio0', 'client_radio1'}
+  for _, radio in ipairs(radios) do
+    if uci:get('wireless', radio) then
+      uci:set('wireless', radio, 'disabled', not enable)
+      execWifi = true
+    end
+  end
+
+  if execWifi then
+    uci:save('wireless')
+    os.execute('wifi')
+  end
+end
+
+if uci:get_bool('ap-timer', 'settings', 'enabled') then
+  local day = getDay()
+  local current = os.date('%H:%M', timestamp)
+
+  local off = compare(uci:get_list('ap-timer', day, 'off'), current)
+  local on = compare(uci:get_list('ap-timer', day, 'on'), current)
+
+  if on and not off then
+    apSet(true)
+  end
+
+  if off and not on then
+    apSet(false)
+  end
+end

--- a/ffho-web-ap-timer/Makefile
+++ b/ffho-web-ap-timer/Makefile
@@ -1,0 +1,18 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ffho-web-ap-timer
+PKG_VERSION:=1
+
+PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
+
+include $(TOPDIR)/../package/gluon.mk
+
+define Package/ffho-web-ap-timer
+  SECTION:=ffho
+  CATEGORY:=FFHO
+  TITLE:=Luci module for ap-timer settings
+  DEPENDS:=+gluon-web-admin
+  MAINTAINER:=Freifunk Hochstift <kontakt@hochstift.freifunk.net>
+endef
+
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))

--- a/ffho-web-ap-timer/ReadMe.md
+++ b/ffho-web-ap-timer/ReadMe.md
@@ -1,0 +1,4 @@
+ffho-web-ap-timer
+=================
+
+Gluon-web module for ap-timer settings.

--- a/ffho-web-ap-timer/i18n/de.po
+++ b/ffho-web-ap-timer/i18n/de.po
@@ -1,0 +1,32 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: 2017-06-24 23:00+0200\n"
+"Last-Translator:  <freifunk@kb-light.de>\n"
+"Language-Team: German\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "AP Timer"
+msgstr "AP Timer"
+
+msgid "Daily"
+msgstr "Täglich"
+
+msgid "Enabled"
+msgstr "Aktiviert"
+
+msgid "OFF"
+msgstr "Aus"
+
+msgid "ON"
+msgstr "An"
+
+msgid "Type"
+msgstr "Typ"
+
+msgid "You can setup the AP Timer here"
+msgstr "Hier kannst du den AP-Timer konfigurieren"

--- a/ffho-web-ap-timer/i18n/ffho-web-ap-timer.pot
+++ b/ffho-web-ap-timer/i18n/ffho-web-ap-timer.pot
@@ -1,0 +1,23 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+msgid "AP Timer"
+msgstr ""
+
+msgid "Daily"
+msgstr ""
+
+msgid "Enabled"
+msgstr ""
+
+msgid "OFF"
+msgstr ""
+
+msgid "ON"
+msgstr ""
+
+msgid "Type"
+msgstr ""
+
+msgid "You can setup the AP Timer here"
+msgstr ""

--- a/ffho-web-ap-timer/luasrc/lib/gluon/config-mode/controller/admin/ap-timer.lua
+++ b/ffho-web-ap-timer/luasrc/lib/gluon/config-mode/controller/admin/ap-timer.lua
@@ -1,0 +1,2 @@
+package 'ffho-web-ap-timer'
+entry({"admin", "ap-timer"}, model("admin/ap-timer"), _("AP Timer"), 30)

--- a/ffho-web-ap-timer/luasrc/lib/gluon/config-mode/model/admin/ap-timer.lua
+++ b/ffho-web-ap-timer/luasrc/lib/gluon/config-mode/model/admin/ap-timer.lua
@@ -1,0 +1,61 @@
+local uci = require('simple-uci').cursor()
+
+pkg_i18n = i18n 'ffho-web-ap-timer'
+
+if not uci:get('ap-timer', 'settings') then
+	uci:section('ap-timer', 'ap-timer', 'settings')
+	uci:save('ap-timer')
+end
+
+if not uci:get('ap-timer', 'all') then
+	uci:section('ap-timer', 'day', 'all')
+	uci:save('ap-timer')
+end
+
+local f = Form(pkg_i18n.translate('AP Timer'), pkg_i18n.translate(
+	'You can setup the AP Timer here'))
+
+local s = f:section(Section)
+
+enabled = s:option(Flag, 'enabled', pkg_i18n.translate('Enabled'))
+enabled.default = uci:get_bool('ap-timer', 'settings', 'enabled')
+enabled.optional = false
+function enabled:write(data)
+	uci:set('ap-timer', 'settings', 'enabled', data)
+end
+
+local timer_type = s:option(ListValue, 'type', pkg_i18n.translate('Type'))
+timer_type.default = uci:get('ap-timer', 'settings', 'type')
+timer_type:depends(enabled, true)
+timer_type:value('day', pkg_i18n.translate('Daily'))
+function timer_type:write(data)
+	uci:set('ap-timer', 'settings', 'type', data)
+end
+
+local s = f:section(Section)
+
+o = s:option(DynamicList, 'on', pkg_i18n.translate('ON'))
+o.default = uci:get_list('ap-timer', 'all', 'on')
+o.placeholder = '06:30'
+o:depends(timer_type, 'day')
+o.optional = false
+o.datatype = 'minlength(5)'
+function o:write(data)
+	uci:set_list('ap-timer', 'all', 'on', data)
+end
+
+o = s:option(DynamicList, 'off', pkg_i18n.translate('OFF'))
+o.default = uci:get_list('ap-timer', 'all', 'off')
+o.placeholder = '23:00'
+o:depends(timer_type, 'day')
+o.optional = false
+o.datatype = 'minlength(5)'
+function o:write(data)
+	uci:set_list('ap-timer', 'all', 'off', data)
+end
+
+function f:write()
+	uci:commit('ap-timer')
+end
+
+return f


### PR DESCRIPTION
People request to be able to configure timeframes when wifi should be disabled automatically.

Freifunk Hochstift has implemented that already so this PR adds their implementation 1:1 to include this in a future build of our firmware