### PR TITLE
ffho-autoupdater-wifi-fallback: upstream changes

### DIFF
--- a/ffho-autoupdater-wifi-fallback/luasrc/usr/lib/lua/autoupdater-wifi-fallback/util.lua
+++ b/ffho-autoupdater-wifi-fallback/luasrc/usr/lib/lua/autoupdater-wifi-fallback/util.lua
@@ -33,7 +33,7 @@ function get_update_hosts(branch)
   local mirrors = uci:get_list('autoupdater', branch, 'mirror')
 
   for _, mirror in ipairs(mirrors) do
-    local host = mirror:match('://%[?([a-zA-Z0-9\:\.]+)%]?/')
+    local host = mirror:match('://%[?([a-zA-Z0-9\-\:\.]+)%]?/')
     table.insert(hosts, 1, host)
   end
   return hosts

--- a/ffho-autoupdater-wifi-fallback/luasrc/usr/sbin/autoupdater-wifi-fallback
+++ b/ffho-autoupdater-wifi-fallback/luasrc/usr/sbin/autoupdater-wifi-fallback
@@ -48,10 +48,10 @@ local function preflight_check()
 end
 
 local function connectivity_check()
-  local f = io.open('/sys/kernel/debug/batman_adv/bat0/gateways', 'r')
+  local f = io.popen('batctl gwl -nH', 'r')
   if f then
     for line in f:lines() do
-      local gateway_mac = line:match('^=?>? +([0-9a-f:]+)')
+      local gateway_mac = line:match('^[ *]+([0-9a-f:]+)')
       if gateway_mac then
         if os.execute('batctl ping -t5 -c1 ' .. gateway_mac .. ' > /dev/null 2>&1') == 0 then
           return true


### PR DESCRIPTION
Didn't test it. But those are the upstream changes.

https://github.com/FreifunkHochstift/ffho-packages/pull/9
https://github.com/FreifunkHochstift/ffho-packages/pull/10