### PR TITLE
Add quotes to grep pattern in radv-filter

### DIFF
--- a/ffmuc-simple-radv-filter/files/lib/gluon/ffmuc-simple-radv-filter/radv-filter
+++ b/ffmuc-simple-radv-filter/files/lib/gluon/ffmuc-simple-radv-filter/radv-filter
@@ -9,7 +9,7 @@ if [ "$?" -ne "0" ]; then
 	ebtables-tiny -P RADV_FILTER DROP
         ebtables-tiny -A FORWARD -p IPv6 -i bat0 --ip6-proto ipv6-icmp --ip6-icmp-type router-advertisement -j RADV_FILTER
 fi 
-ebtables=$(ebtables-tiny -L RADV_FILTER | grep -q $gwl)
+ebtables=$(ebtables-tiny -L RADV_FILTER | grep -q "$gwl")
 if [ "$?" -ne "0" ]; then
 	logger -t radv_filter_simple "Setting IPv6 Gateway to $gwl"
 	ebtables-tiny -F RADV_FILTER


### PR DESCRIPTION
If batctl does not list a gateway this results in an empty grep pattern variable which requires quotes

This fixes #20. Alternative would be to check for an empty $gwl variable and exit early