### PR TITLE
Adding package for ffulm migration

### DIFF
--- a/ffulm-migration/Makefile
+++ b/ffulm-migration/Makefile
@@ -1,0 +1,45 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ffulm-migration
+PKG_VERSION:=1
+PKG_LICENSE:=MIT
+
+PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
+
+include $(TOPDIR)/../package/gluon.mk
+
+define Package/$(PKG_NAME)
+  SECTION:=gluon
+  CATEGORY:=Gluon
+  TITLE:=ffulm migration
+  DEPENDS:=+gluon-core
+  MAINTAINER:=Freifunk München <muenchen@freifunk.net>
+endef
+
+define Package/$(PKG_NAME)/description
+	Package that migrates ffulm non-Gluon configs to a Gluon config and then reboots
+endef
+
+init_links := \
+	K89log \
+	K98boot \
+	K99umount \
+	S00sysfixtime \
+  	S00urngd \
+	S10boot \
+	S10gluon-core-reconfigure \
+	S10system \
+	S11sysctl \
+	S12log \
+	S20gluon-core-reconfigure \
+	S95done
+
+define Package/$(PKG_NAME)/install
+	$(Gluon/Build/Install)
+
+	for link in $(init_links); do \
+		$(LN) "/etc/init.d/$$$${link:3}" "$(1)/lib/gluon/ffulm-migration/rc.d/$$$${link}"; \
+	done
+endef
+
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))

--- a/ffulm-migration/README.md
+++ b/ffulm-migration/README.md
@@ -1,0 +1,50 @@
+# ffulm-migration
+
+This packages allows migrating an ffulm firmware v2.1.5 to a gluon-based v2021.1.x firmware.
+The fundamentals are inspired by setup-mode.
+
+It creates its own rc.d tree that can be enforced by writing a path into the file `/tmp/rc_d_path` early during boot.
+This happens inside a preinit file called "89_ffulm_migration" that is exected just before the preinit file of
+gluon-setup-mode. In order to avoid conflicts with setup-mode, this preinit file also disables it (enabled=0) and
+pretends that it had been configured in the past (configured=1).
+
+These steps are being used from /etc/rc.d:
+- `K89log`
+- `K98boot`
+- `K99umount`
+- `S00sysfixtime`
+- `S00urngd`
+- `S10boot`
+- `S10gluon-core-reconfigure`
+- `S10system`
+- `S11sysctl`
+- `S12log`
+- `S20gluon-core-reconfigure`
+- `S95done`
+
+And we inject our own custom rc stages:
+- `S09ffulm-config-backup`\
+  This stage will remove and backup all previous files in /etc/config and restore the defaults from /rom/etc/config
+- `S13led`\
+  This stage will make the LED flash fast to show that the migration is in progress
+- `S14ffulm-migration`\
+  This stage is doing the migration of previous configs to a Gluon configuration (and can be extended if needed)
+- `S19ffulm-cleanup`\
+  This stage will clean up the backed up configurations (if permitted), will remove other remnant configuration files (like old cronjobs, /etc/hosts, etc) and will reset the root password (if permitted)
+- `S96reboot`\
+  This stage will write a logread dump to /root and reboot the router into a real Gluon (if permitted)
+
+
+## Special uci overrides
+
+These overrides allow to customise the migration:
+
+- `freifunk.@settings[0].preserve_configs`\
+  Set to any value, will not delete any of the backup files from previous /etc/config. Helpful for further debugging.
+
+- `freifunk.@settings[0].preserve_root_password=i_know_what_i_am_doing`\
+  This flag will not reset the root password.\
+  ⚠️WARNING⚠️: The router will be publicly reachable after an upgrade and we highly recommend to only use SSH-keys for accessing a router.
+
+- `freifunk.@settings[0].disable_migration_reboot`\
+  Set to any value, will not reboot after the migration. The device will only be accessible via a serial console.

--- a/ffulm-migration/files/lib/gluon/ffulm-migration/migration-tools.sh
+++ b/ffulm-migration/files/lib/gluon/ffulm-migration/migration-tools.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+export FFULM_PREFIX="ffulm_"
+
+migration_log() {
+    topic=$1
+    shift
+    level=$1
+    shift
+
+    logger -t "$topic" -p "$level" "${@}"
+    echo "$(date -u | sed 's/UTC //') user.${level} ${topic}: " "${@}" >> /root/ffulm-migration.log
+}

--- a/ffulm-migration/files/lib/gluon/ffulm-migration/rc.d/S09ffulm-config-backup
+++ b/ffulm-migration/files/lib/gluon/ffulm-migration/rc.d/S09ffulm-config-backup
@@ -1,0 +1,32 @@
+#!/bin/sh /etc/rc.common
+
+# shellcheck disable=SC2034
+START=09
+
+boot() {
+    # shellcheck source=ffulm-migration/files/lib/gluon/ffulm-migration/migration-tools.sh
+    . /lib/gluon/ffulm-migration/migration-tools.sh
+
+    migration_log ffulm-config-backup notice "Starting ffulm config backup"
+
+    migration_log ffulm-config-backup notice "Prefixing all ffulm uci configs with ${FFULM_PREFIX}..."
+    cd /etc/config/ || exit 1
+    for file in *
+    do
+        if [ "${file#*"${FFULM_PREFIX}"}" != "$file" ]; then
+            migration_log ffulm-config-backup warn "Found existing ffulm backup: ${file}"
+            continue
+        fi
+        mv -vn "${file}" "${FFULM_PREFIX}${file}" && \
+        migration_log ffulm-config-backup info "Created backup of ffulm uci config: ${file}"
+    done
+
+    # manually restore all default configs from /rom as those should have been written during config
+    # warning: only works if overlayfs is being used. If not, only a successive sysupgrade can restore the files.
+    cd /rom/etc/config || exit 1
+    for file in *
+    do
+        cp -dp "/rom/etc/config/${file}" "/etc/config/${file}" && \
+        migration_log ffulm-config-backup info "Restoring uci config from /rom: ${file}"
+    done
+}

--- a/ffulm-migration/files/lib/gluon/ffulm-migration/rc.d/S13led
+++ b/ffulm-migration/files/lib/gluon/ffulm-migration/rc.d/S13led
@@ -1,0 +1,11 @@
+#!/bin/sh /etc/rc.common
+
+# shellcheck disable=SC2034
+START=13
+
+start() {
+        /etc/init.d/led start
+        # shellcheck source=/dev/null
+        . /etc/diag.sh
+        set_state failsafe
+}

--- a/ffulm-migration/files/lib/gluon/ffulm-migration/rc.d/S14ffulm-migration
+++ b/ffulm-migration/files/lib/gluon/ffulm-migration/rc.d/S14ffulm-migration
@@ -1,0 +1,62 @@
+#!/bin/sh /etc/rc.common
+
+# shellcheck disable=SC2034
+START=14
+
+boot() {
+    # shellcheck source=ffulm-migration/files/lib/gluon/ffulm-migration/migration-tools.sh
+    . /lib/gluon/ffulm-migration/migration-tools.sh
+
+    ffulm_domain="ffmuc_welt" # TODO change to ulm
+
+    migration_log ffulm-migration notice "Starting ffulm config migration"
+
+    # Try to migrate the hostname
+    if pretty_hostname=$(uci -q get "${FFULM_PREFIX}freifunk.@settings[0].name")
+    then
+        pretty-hostname "${pretty_hostname}"
+        migration_log ffulm-migration info "Migrated hostname: ${pretty_hostname} and $(uci get 'system.@system[0].hostname')"
+
+    fi
+
+    # Try to migrate the owner
+    if owner=$(uci -q get "${FFULM_PREFIX}freifunk.@settings[0].contact")
+    then
+        uci -q get gluon-node-info.@owner[0] >/dev/null || uci add gluon-node-info owner
+        uci set 'gluon-node-info.@owner[0].contact'="${owner}"
+        uci commit gluon-node-info
+        migration_log ffulm-migration info "Migrated owner: ${owner}"
+    fi
+
+    # Try to migrate the location
+    if long=$(uci -q get "${FFULM_PREFIX}freifunk.@settings[0].longitude") && lat=$(uci -q get "${FFULM_PREFIX}freifunk.@settings[0].latitude")
+    then
+        uci set 'gluon-node-info.@location[0].share_location'="1"
+        uci set 'gluon-node-info.@location[0].latitude'="${lat}"
+        uci set 'gluon-node-info.@location[0].longitude'="${long}"
+        uci commit gluon-node-info
+        migration_log ffulm-migration info "Migrated long/lat: ${long}/${lat}"
+    fi
+
+    if mesh_on_wan=$(uci -q get "${FFULM_PREFIX}freifunk.@settings[0].mesh_on_wan")
+    then
+        # if Mesh-on-WAN is enabled we do not want to enable the conflicting Mesh VPN
+        if [ "$mesh_on_wan" = "1" ];
+        then
+            uci set gluon.mesh_vpn.enabled=0
+        else
+            uci set gluon.mesh_vpn.enabled=1
+        fi
+        migration_log ffulm-migration info "Migrated mesh_vpn: not ${mesh_on_wan}"
+
+        # trigger reconfigure later in S20
+        uci set gluon.core.reconfigure=1
+        uci commit gluon
+    fi
+
+    # Set domain
+    migration_log ffulm-migration info "Set domain to ${ffulm_domain}"
+    uci set gluon.core.domain="${ffulm_domain}"
+    uci set gluon.core.reconfigure=1
+    uci commit gluon
+}

--- a/ffulm-migration/files/lib/gluon/ffulm-migration/rc.d/S19ffulm-cleanup
+++ b/ffulm-migration/files/lib/gluon/ffulm-migration/rc.d/S19ffulm-cleanup
@@ -1,0 +1,94 @@
+#!/bin/sh /etc/rc.common
+
+# Needs to start just before the next gluon-reconfigure
+# shellcheck disable=SC2034
+START=19
+
+boot() {
+    # shellcheck source=ffulm-migration/files/lib/gluon/ffulm-migration/migration-tools.sh
+    . /lib/gluon/ffulm-migration/migration-tools.sh
+
+    migration_log ffulm-cleanup notice "Starting ffulm cleanup"
+
+    cleanup_misc_files() {
+        # delete ffulm remnants that are not needed anymore and can cause conflicts
+        for file in \
+            /etc/crontabs/root \
+            /etc/firewall.user \
+            /etc/opkg/keys/* \
+            /etc/sysctl.conf \
+            /etc/sysupgrade.conf \
+            /etc/uhttpd.crt \
+            /etc/uhttpd.key \
+            ;
+        do
+            if rm "${file}"; then
+                migration_log ffulm-cleanup info "Deleted ${file}"
+            else
+                migration_log ffulm-cleanup warn "Failed to delete ${file}"
+            fi
+        done
+    }
+
+    cleanup_configs() {
+        for file in "/etc/config/${FFULM_PREFIX}"*
+        do
+            rm "${file}" && migration_log ffulm-cleanup info "Deleted ${file}"
+        done
+    }
+
+    # Delete entries like "10.33.127.0 node"
+    cleanup_etc_hosts() {
+        line_regex='10\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\} node'
+        hosts_file=/etc/hosts
+        if matched_line=$(grep "${line_regex}" ${hosts_file}); then
+            sed -i "/${line_regex}/d" ${hosts_file}
+            migration_log ffulm-cleanup info "Deleting the following line from ${hosts_file}: ${matched_line}"
+        else
+            migration_log ffulm-cleanup warn "Failed to find regex ${line_regex} in ${hosts_file}: $(cat ${hosts_file})"
+        fi
+    }
+
+    delete_root_password() {
+        if [ ! -e /etc/dropbear/authorized_keys ]
+        then
+            migration_log ffulm-cleanup warn "Did not find an authorized_key file. Remote access will only be possible via SSH-key."
+        fi
+
+        if [ "$(wc -l /etc/dropbear/authorized_keys | awk '{print $1}')" -lt 1 ]
+        then
+            migration_log ffulm-cleanup warn "Found no key in authorized_key file. Remote access will only be possible via SSH-key."
+        fi
+
+        # Unfortunately the default password is an empty password with a salt+hash that cannot be easily distinguished on the device
+        # We decided to lock out users without an SSH key in order to have no compromised devices.
+        passwd -d -l root && migration_log ffulm-cleanup notice "Deleted root password and locked account"
+    }
+
+
+    # Start the cleanup process
+    # See also https://github.com/freifunkMUC/site-ffm/pull/370#issuecomment-2041163451
+
+    cleanup_misc_files
+    cleanup_etc_hosts
+
+    # Only wipe configs if there has no override been specified
+    if ! uci -q get ${FFULM_PREFIX}freifunk.@settings[0].preserve_configs
+    then
+        cleanup_configs
+    else
+        migration_log ffulm-cleanup warn "Preserving files in /etc/config/${FFULM_PREFIX}..."
+    fi
+
+    # Preserve root password if user has overwritten it
+    if preserve_root_password=$(uci -q get ${FFULM_PREFIX}freifunk.@settings[0].preserve_root_password)
+    then
+        if [ "$preserve_root_password" = "i_know_what_i_am_doing" ]; then
+            migration_log ffulm-cleanup warn "Preserving root password."
+        else
+            delete_root_password
+        fi
+    else
+        delete_root_password
+    fi
+}

--- a/ffulm-migration/files/lib/gluon/ffulm-migration/rc.d/S96reboot
+++ b/ffulm-migration/files/lib/gluon/ffulm-migration/rc.d/S96reboot
@@ -1,0 +1,19 @@
+#!/bin/sh /etc/rc.common
+
+# shellcheck disable=SC2034
+START=96
+
+boot() {
+    # shellcheck source=ffulm-migration/files/lib/gluon/ffulm-migration/migration-tools.sh
+    . /lib/gluon/ffulm-migration/migration-tools.sh
+
+    migration_log ffulm-reboot notice "Finished migration"
+
+    # Try to dump logread
+    logread > /root/ffulm-migration-logread.txt || true
+    sync
+
+    if ! uci -q get ${FFULM_PREFIX}freifunk.@settings[0].disable_migration_reboot; then
+        reboot
+    fi
+}

--- a/ffulm-migration/files/lib/gluon/upgrade/000-check-for-ffulm-configs
+++ b/ffulm-migration/files/lib/gluon/upgrade/000-check-for-ffulm-configs
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Double check that during the gluon-reconfigure there is no more "freifunk" config
+[ ! -e /etc/config/freifunk ] && exit 0
+
+# shellcheck source=ffulm-migration/files/lib/gluon/ffulm-migration/migration-tools.sh
+. /lib/gluon/ffulm-migration/migration-tools.sh
+
+migration_log ffulm-gluon-upgrade err "ERROR: Found /etc/config/freifunk as part of gluon-reconfigure"

--- a/ffulm-migration/files/lib/preinit/89_ffulm_migration
+++ b/ffulm-migration/files/lib/preinit/89_ffulm_migration
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+
+
+ffulm_migration_enable() {
+	# WARNING: we are assuming that freifunk setting are only from ffulm.
+	# This might cause conflicts for other firmware migrations in the future that use the same uci config
+	if uci -q get 'freifunk.@settings[0]' > /dev/null
+	then
+		# shellcheck source=ffulm-migration/files/lib/gluon/ffulm-migration/migration-tools.sh
+		. /lib/gluon/ffulm-migration/migration-tools.sh
+
+		migration_log ffulm-migration notice "Enabling ffulm config migration"
+
+		echo '/lib/gluon/ffulm-migration/rc.d' > /tmp/rc_d_path
+
+		# Force-disabled setup-mode to avoid conflicts with /tmp/rc_d_path
+		uci set 'gluon-setup-mode.@setup_mode[0].enabled'=0
+		uci set 'gluon-setup-mode.@setup_mode[0].configured'=1
+	fi
+}
+
+boot_hook_add preinit_main ffulm_migration_enable


### PR DESCRIPTION
This custom package allows the migration of non-Gluon ffulm firmware to a
gluon-based firmware.

It was tested with ffmuc v2022.5.6 which is based on Gluon v2021.1.x.